### PR TITLE
fix #7: add support for specializations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
        --output modelrepository.archiplugin && \
     unzip modelrepository.archiplugin -d /root/.archi4/dropins/ && \
     rm modelrepository.archiplugin && \
-    wget https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_darwin_amd64 -O /usr/bin/yq &&\
+    curl -O https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_darwin_amd64 -output /usr/bin/yq &&\
     chmod +x /usr/bin/yq
 
 COPY entrypoint.sh /opt/Archi/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
       git \
       openssh-client \
       unzip && \
-      yq && \
     apt-get clean && \
     update-ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
@@ -40,7 +39,9 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
        --data-raw "zoob=coArchi_$COARCHI_VERSION.archiplugin" \
        --output modelrepository.archiplugin && \
     unzip modelrepository.archiplugin -d /root/.archi4/dropins/ && \
-    rm modelrepository.archiplugin
+    rm modelrepository.archiplugin && \
+    wget https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_darwin_amd64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
 
 COPY entrypoint.sh /opt/Archi/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
       git \
       openssh-client \
       unzip && \
+      yq && \
     apt-get clean && \
     update-ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,8 +153,7 @@ fi
 
 # Get project title
 if [ -f "$ARCHI_PROJECT_PATH/model/folder.xml" ]; then
-  _project="$(grep -Po 'name="\K([^"]*)' \
-    "$ARCHI_PROJECT_PATH/model/folder.xml")"
+  _project="$(yq -p=xml '.ArchimateModel.+name' "$ARCHI_PROJECT_PATH/model/folder.xml")"
 elif [ -n "${GIT_REPOSITORY:-}" ]; then
   _project="$(basename -s .git "$GIT_REPOSITORY")"
 else


### PR DESCRIPTION
Fix the #7 

Like described in the comment of the issue, I installed yq that will allow the correct retrieval of the name of the archimate model without the specialization ones.