### PR TITLE
Added support for high DPI.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,19 +25,19 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 FROM base AS archi
-ARG ARCHI_VERSION=5.0.2
+ARG ARCHI_VERSION=5.1.0
 
 # Download & extract Archimate tool
 RUN set -eux; \
     curl -#Lo archi.tgz \
-      "https://www.archimatetool.com/downloads/archi.php?/$ARCHI_VERSION/Archi-Linux64-$ARCHI_VERSION.tgz"; \
+      "https://www.archimatetool.com/downloads/archi5.php?/$ARCHI_VERSION/Archi-Linux64-$ARCHI_VERSION.tgz"; \
     tar zxf archi.tgz -C /opt/; \
     rm archi.tgz; \
     chmod +x /opt/Archi/Archi; \
     mkdir -p /root/.archi/dropins /archi/report /archi/project
 
 FROM archi AS coarchi
-ARG COARCHI_VERSION=0.8.7
+ARG COARCHI_VERSION=0.8.8
 
 # Download & extract Archimate coArchi plugin
 RUN set -eux; \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ docker run --rm -ti \
   -e ARCHI_JASPER_REPORT_ENABLED=false \
   -e ARCHI_CSV_REPORT_ENABLED=true \
   -e ARCHI_EXPORT_MODEL_ENABLED=true \
+  -e SCREEN_DPI=192 \
   ghcr.io/woozymasta/archimate-ci-image:5.0.2-1.0.4
 ```
 
@@ -121,6 +122,8 @@ Options for managing model export:
   format.
 * **`ARCHI_EXPORT_MODEL_PATH`**=`$ARCHI_REPORT_PATH` - Path for save model;
 * **`ARCHI_APP`**=`com.archimatetool.commandline.app` application name.
+* **`SCREEN_DPI`**=`96` - DPI of the generated images, change to 192 for 200%
+  scaling;
 * **`DEBUG`**=`false` - enable `bash -x`
 
 ### GitHub Actions Configuration
@@ -149,6 +152,7 @@ All inputs equivalent to environment variables:
 * `githubPagesDomain`
 * `githubPagesBranch`
 * `gitSubtreePrefix`
+* `screenDpi`
 * `debugAction`
 
 ## GitHub Actions Example
@@ -177,6 +181,7 @@ jobs:
           archiCsvReportEnabled: false
           archiExportModelEnabled: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          screenDpi: 192
 ```
 
 In the repository settings, set the branch for publishing pages that you

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ runs:
     GITHUB_PAGES_DOMAIN: ${{ inputs.githubPagesDomain }}
     GITHUB_PAGES_BRANCH: ${{ inputs.githubPagesBranch }}
     GIT_SUBTREE_PREFIX: ${{ inputs.gitSubtreePrefix }}
+    SCREEN_DPI: ${{ inputs.screenDpi }}
     DEBUG: ${{ inputs.debugAction }}
 
 inputs:
@@ -56,6 +57,9 @@ inputs:
     required: false
   gitSubtreePrefix:
     description: Directory for store reports in model branch
+    required: false
+  screenDpi:
+    description: DPI of the generated images
     required: false
   debugAction:
     description: bash -x

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 : "${ARCHI_CSV_REPORT_ENABLED:=false}"
 : "${ARCHI_EXPORT_MODEL_ENABLED:=true}"
 : "${ARCHI_APP:=com.archimatetool.commandline.app}"
+: "${SCREEN_DPI:=96}"
 
 : "${GITHUB_SERVER_URL:=https://github.com}"
 : "${GITHUB_PAGES_BRANCH:=gh-pages}"
@@ -79,7 +80,7 @@ archi_run() {
     )
 
   # Run Archi
-  xvfb-run \
+  xvfb-run --server-args="-dpi $SCREEN_DPI" \
     /opt/Archi/Archi -application "$ARCHI_APP" -consoleLog -nosplash \
       --modelrepository.loadModel "$ARCHI_PROJECT_PATH" "${_args[@]}" &&
   printf '\n%s\n\n' "Done. Reports saved to $ARCHI_REPORT_PATH"
@@ -147,7 +148,7 @@ fail() { printf >&2 '%s\n' "$*"; exit 1; }
 # Run custom archi command
 if [ "$#" -ge 1 ]; then
   echo "Execute Archi with _args: $*"
-  xvfb-run \
+  xvfb-run --server-args="-dpi $SCREEN_DPI" \
     /opt/Archi/Archi -application "$ARCHI_APP" -consoleLog -nosplash "$@"
   exit 0
 fi


### PR DESCRIPTION
xvfb-run allows the DPI to be set through the server args option. A new environment variable SCREEN_DPI has been added to allow this setting to be changed. It defaults to 96, the current default of xvfb-run. Setting it to e.g. 192 will double the resolution of all images generated.